### PR TITLE
Fix: Issues with the import and callbacks

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var assertThat = require('../lib/assertthat-bdd');
+var assertThat = require('./lib/assertthat-bdd');
 var _ = require('underscore');
 
 var defaults = {

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 'use strict'
 
-var assertThat = require('./lib/assertthat-bdd');
-var _ = require('underscore');
+const assertThat = require('./lib/assertthat-bdd');
+const _ = require('underscore');
 
-var defaults = {
+const defaults = {
     accessKey: process.env.ASSERTTHAT_ACCESS_KEY,
     secretKey: process.env.ASSERTTHAT_SECRET_KEY,
     jsonReportFolder: './reports/',

--- a/index.js
+++ b/index.js
@@ -32,15 +32,11 @@ function checkArgs(settings){
 module.exports = {
     downloadFeatures:  function(settings, callback) {
         settings = checkArgs(settings);
-        assertThat.downloadFeatures(settings, function() {
-            if (callback) callback();
-        });
+        assertThat.downloadFeatures(settings, callback);
     },
     uploadReports: function(settings, callback) {
         console.log(settings);
         settings = checkArgs(settings);
-        assertThat.uploadReports(settings, function() {
-            if (callback) callback();
-        });
+        assertThat.uploadReports(settings, callback);
     }
 }

--- a/lib/assertthat-bdd.js
+++ b/lib/assertthat-bdd.js
@@ -67,10 +67,10 @@ const uploadReports = async function(settings, callback) {
             console.log('sending file ' + filename + ' with runId ' + runId);
            const res = sendReport(settings,filename,runId);
            await res.then(res => { runId=JSON.parse(res.text).runId});
-           if(callback) callback();
         }
     }
-
+    
+    if(callback) callback();
 };
 
 async function sendReport(settings, filename, runId){

--- a/lib/assertthat-bdd.js
+++ b/lib/assertthat-bdd.js
@@ -54,6 +54,7 @@ var downloadFeatures = function(settings, callback) {
         var zip = new admZip(settings.outputFolder+'/features.zip');
         zip.extractAllTo( settings.outputFolder, true);
         fs.unlinkSync(settings.outputFolder+'/features.zip');
+        callback();
       });
 };
 
@@ -66,7 +67,7 @@ var uploadReports = async function(settings, callback) {
             console.log('sending file ' + filename + ' with runId ' + runId);
            var res = sendReport(settings,filename,runId);
            await res.then(res => { runId=JSON.parse(res.text).runId});
-
+           callback();
         }
     }
 

--- a/lib/assertthat-bdd.js
+++ b/lib/assertthat-bdd.js
@@ -54,7 +54,7 @@ const downloadFeatures = function(settings, callback) {
         const zip = new admZip(settings.outputFolder+'/features.zip');
         zip.extractAllTo( settings.outputFolder, true);
         fs.unlinkSync(settings.outputFolder+'/features.zip');
-        callback();
+        if(callback) callback();
       });
 };
 
@@ -67,7 +67,7 @@ const uploadReports = async function(settings, callback) {
             console.log('sending file ' + filename + ' with runId ' + runId);
            const res = sendReport(settings,filename,runId);
            await res.then(res => { runId=JSON.parse(res.text).runId});
-           callback();
+           if(callback) callback();
         }
     }
 

--- a/lib/assertthat-bdd.js
+++ b/lib/assertthat-bdd.js
@@ -5,10 +5,10 @@ const admZip = require('adm-zip');
 const request = require('superagent');
 require('superagent-proxy')(request);
 const fs = require('fs');
-var path = require('path')
+const path = require('path')
 
-var downloadFeatures = function(settings, callback) {
-    var featuresUrl = "https://bdd.assertthat.app/rest/api/1/project/" + settings.projectId + "/features"
+const downloadFeatures = function(settings, callback) {
+    let featuresUrl = "https://bdd.assertthat.app/rest/api/1/project/" + settings.projectId + "/features"
     if(settings.jiraServerUrl){
         featuresUrl = settings.jiraServerUrl+"/rest/assertthat/latest/project/"+settings.projectId+"/client/features"
     }
@@ -44,28 +44,28 @@ var downloadFeatures = function(settings, callback) {
       })
       .pipe(fs.createWriteStream(settings.outputFolder+'/features.zip'))
       .on('finish', function() {
-        var files=fs.readdirSync(settings.outputFolder);
-        for(var i=0;i<files.length;i++){
-            var filename=path.join(settings.outputFolder,files[i]);
+        const files=fs.readdirSync(settings.outputFolder);
+        for(let i=0;i<files.length;i++){
+            let filename=path.join(settings.outputFolder,files[i]);
             if (filename.indexOf('.feature')>=0) {
                 fs.unlinkSync(filename);
             }
         }
-        var zip = new admZip(settings.outputFolder+'/features.zip');
+        const zip = new admZip(settings.outputFolder+'/features.zip');
         zip.extractAllTo( settings.outputFolder, true);
         fs.unlinkSync(settings.outputFolder+'/features.zip');
         callback();
       });
 };
 
-var uploadReports = async function(settings, callback) {
-    var files = fs.readdirSync(settings.jsonReportFolder);
-    var runId = -1;
-    for(var i=0;i<files.length;i++){
-        var filename=path.join(settings.jsonReportFolder,files[i]);
+const uploadReports = async function(settings, callback) {
+    const files = fs.readdirSync(settings.jsonReportFolder);
+    let runId = -1;
+    for(let i=0;i<files.length;i++){
+        let filename=path.join(settings.jsonReportFolder,files[i]);
         if (filename.indexOf('.json')>=0) {
             console.log('sending file ' + filename + ' with runId ' + runId);
-           var res = sendReport(settings,filename,runId);
+           const res = sendReport(settings,filename,runId);
            await res.then(res => { runId=JSON.parse(res.text).runId});
            callback();
         }
@@ -74,16 +74,16 @@ var uploadReports = async function(settings, callback) {
 };
 
 async function sendReport(settings, filename, runId){
-    var reportUrl = "https://bdd.assertthat.app/rest/api/1/project/" + settings.projectId + "/report"
+    let reportUrl = "https://bdd.assertthat.app/rest/api/1/project/" + settings.projectId + "/report"
     if(settings.jiraServerUrl){
         reportUrl = settings.jiraServerUrl+"/rest/assertthat/latest/project/"+settings.projectId+"/client/report"
     }
     const req =  request.post(reportUrl)
-    var newRunId = runId;
+    
     if(settings.proxyURI){
         req.proxy(settings.proxyURI)
     }
-    var metadata = '';
+    let metadata = '';
     if (fs.existsSync(settings.metadata)){
        metadata = fs.readFileSync(settings.metadata, 'utf8');
     }


### PR DESCRIPTION
This Pr includes 
- Require path fix for lib `assertthat-bdd` in `index.js`
- Executing the `callback()` in upload and download functions of `assertthat-bdd` library  
- Cleanup: Replacement of `let` and `const` instead of var 
